### PR TITLE
Fix is_last_step bug in Pregel

### DIFF
--- a/langgraph/pregel/__init__.py
+++ b/langgraph/pregel/__init__.py
@@ -1051,7 +1051,7 @@ def _apply_writes(
 
     # Update reserved channels
     pending_writes_by_channel[ReservedChannels.is_last_step] = [
-        for_step + 1 == config["recursion_limit"]
+        for_step == config["recursion_limit"]
     ]
 
     updated_channels: set[str] = set()


### PR DESCRIPTION
## Summary
- fix off-by-one error when updating `is_last_step`

## Testing
- `pytest -q` *(fails: command not found)*